### PR TITLE
Add `drb` as a dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ Hoe.spec "minitest-server" do
   license "MIT"
 
   dependency "minitest", "~> 5.16"
+  dependency "drb", "~> 2.0"
 end
 
 # vim: syntax=ruby


### PR DESCRIPTION
Since Ruby 3.3.0, RubyGems and Bundler warn if users do require the gems that will become the bundled gems in the future version of Ruby.

Please see the "Standard library updates" section for the details. https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/

`minitest-server` uses `drb`. This fixes the following warning.

```
minitest-server-1.0.7/lib/minitest/server.rb:1: warning: drb was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add drb to your Gemfile or gemspec. Also contact author of minitest-server-1.0.7 to add drb into its gemspec.
```